### PR TITLE
Fix Angular doesn't compile when @Input/@Output are private

### DIFF
--- a/projects/ngu-carousel/src/lib/ngu-carousel/ngu-carousel.component.ts
+++ b/projects/ngu-carousel/src/lib/ngu-carousel/ngu-carousel.component.ts
@@ -59,12 +59,25 @@ export class NguCarousel<T> extends NguCarouselStore
   private withAnim = true;
   activePoint: number;
   isHovered = false;
+  private inputs: NguCarouselConfig;
+  // tslint:disable-next-line:no-input-rename
+  @Input('inputs') public set publicInputs(inputs: NguCarouselConfig) {
+    this.inputs = inputs; 
+  }
+  private crouselLoad = new EventEmitter();
+  // tslint:disable-next-line:no-input-rename
+  @Output('carouselLoad') 
+  get publicCarouselLoad(): EventEmitter {
+    return this.carouselLoad;
+  }
 
-  @Input() private inputs: NguCarouselConfig;
-  @Output() private carouselLoad = new EventEmitter();
-
+  private onMove = new EventEmitter<NguCarousel<T>>();
   // tslint:disable-next-line:no-output-on-prefix
-  @Output() private onMove = new EventEmitter<NguCarousel<T>>();
+  // tslint:disable-next-line:no-input-rename
+  @Output('onMove')
+  get publicOnMove(): EventEmitter<NguCarousel<T>> {
+    return this.onMove;
+  }
   // isFirstss = 0;
   arrayChanges: IterableChanges<{}>;
   carouselInt: Subscription;


### PR DESCRIPTION
Angular complain about passing data to @Input fields that are private 

What I have done is:
- instead of private use public getters without setters for @Output and return an alternative private field
- instead of private use public setters without getters for @Input and set an alternative private field
- might need to prefix the new private fields with _ prefix for consistency

I apologize for the bad pull request message this is my first ever pull request